### PR TITLE
Database setup

### DIFF
--- a/app/models/cage.rb
+++ b/app/models/cage.rb
@@ -1,0 +1,7 @@
+class Cage < ApplicationRecord
+  validates :capacity, presence: true
+
+  enum role: {DOWN: 0, ACTIVE: 1}
+
+  has_many :dinosaurs
+end

--- a/app/models/dinosaur.rb
+++ b/app/models/dinosaur.rb
@@ -3,5 +3,5 @@ class Dinosaur < ApplicationRecord
   validates :species, presence: true
   validates :food_type, presence: true
 
-  # belongs_to :cages
+  belongs_to :cage
 end

--- a/app/models/dinosaur.rb
+++ b/app/models/dinosaur.rb
@@ -1,0 +1,7 @@
+class Dinosaur < ApplicationRecord
+  validates :name, presence: true
+  validates :species, presence: true
+  validates :food_type, presence: true
+
+  # belongs_to :cages
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,85 @@
-# SQLite. Versions 3.8.0 and up are supported.
-#   gem install sqlite3
+# PostgreSQL. Versions 9.3 and up are supported.
 #
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
+# Install the pg driver:
+#   gem install pg
+# On macOS with Homebrew:
+#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+# On macOS with MacPorts:
+#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
+# On Windows:
+#   gem install pg
+#       Choose the win32 build.
+#       Install PostgreSQL and put its /bin directory on your path.
+#
+# Configure Using Gemfile
+# gem 'pg'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
+  # For details on connection pooling, see Rails configuration guide
+  # https://guides.rubyonrails.org/configuring.html#database-poolinga
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: jurassic_park_development
+
+  # The specified database role being used to connect to postgres.
+  # To create additional roles in postgres see `$ createuser --help`.
+  # When left blank, postgres will use the default role. This is
+  # the same name as the operating system user that initialized the database.
+  #username: lienflash_be
+
+  # The password associated with the postgres role (username).
+  #password:
+
+  # Connect on a TCP socket. Omitted by default since the client uses a
+  # domain socket that doesn't need configuration. Windows does not have
+  # domain sockets, so uncomment these lines.
+  #host: localhost
+
+  # The TCP port the server listens on. Defaults to 5432.
+  # If your server runs on a different port number, change accordingly.
+  #port: 5432
+
+  # Schema search path. The server defaults to $user,public
+  #schema_search_path: myapp,sharedapp,public
+
+  # Minimum log levels, in increasing order:
+  #   debug5, debug4, debug3, debug2, debug1,
+  #   log, notice, warning, error, fatal, and panic
+  # Defaults to warning.
+  #min_messages: notice
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: jurassic_park_test
 
-production:
-  <<: *default
-  database: db/production.sqlite3
+# As with config/credentials.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
+#
+# Instead, provide the password as a unix environment variable when you boot
+# the app. Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full rundown on how to provide these environment variables in a
+# production deployment.
+#
+# On Heroku and other platform providers, you may have a full connection URL
+# available as an environment variable. For example:
+#
+#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
+#
+# You can use this database configuration with:
+#
+#   production:
+#     url: <%= ENV['DATABASE_URL'] %>
+#
+# production:
+#   <<: *default
+#   database: jurassic_park_production
+#   username: jurassic_park
+#   password: <%= ENV['JURASSIC_PARK_DATABASE_PASSWORD'] %>

--- a/db/migrate/20210204165407_create_dinosaurs.rb
+++ b/db/migrate/20210204165407_create_dinosaurs.rb
@@ -1,0 +1,11 @@
+class CreateDinosaurs < ActiveRecord::Migration[6.0]
+  def change
+    create_table :dinosaurs do |t|
+      t.string :name
+      t.string :species
+      t.string :food_type
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210204170800_create_cages.rb
+++ b/db/migrate/20210204170800_create_cages.rb
@@ -1,0 +1,10 @@
+class CreateCages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :cages do |t|
+      t.integer :capacity
+      t.integer :power_status, default: 1
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210204171307_add_cage_to_dinosaurs.rb
+++ b/db/migrate/20210204171307_add_cage_to_dinosaurs.rb
@@ -1,0 +1,5 @@
+class AddCageToDinosaurs < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :dinosaurs, :cage, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_04_165407) do
+ActiveRecord::Schema.define(version: 2021_02_04_171307) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "cages", force: :cascade do |t|
+    t.integer "capacity"
+    t.integer "power_status", default: 1
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "dinosaurs", force: :cascade do |t|
     t.string "name"
@@ -21,6 +28,9 @@ ActiveRecord::Schema.define(version: 2021_02_04_165407) do
     t.string "food_type"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "cage_id", null: false
+    t.index ["cage_id"], name: "index_dinosaurs_on_cage_id"
   end
 
+  add_foreign_key "dinosaurs", "cages"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,26 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2021_02_04_165407) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "dinosaurs", force: :cascade do |t|
+    t.string "name"
+    t.string "species"
+    t.string "food_type"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end

--- a/spec/models/cage_spec.rb
+++ b/spec/models/cage_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Cage, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of :capacity }
+
+    describe 'relationships' do
+      it { should have_many :dinosaurs }
+    end
+  end
+end

--- a/spec/models/dinosaur_spec.rb
+++ b/spec/models/dinosaur_spec.rb
@@ -6,5 +6,8 @@ RSpec.describe Dinosaur, type: :model do
     it { should validate_presence_of :species }
     it { should validate_presence_of :food_type }
 
+    describe 'relationships' do
+      it { should belong_to :cage }
+    end
   end
 end

--- a/spec/models/dinosaur_spec.rb
+++ b/spec/models/dinosaur_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Dinosaur, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of :name }
+    it { should validate_presence_of :species }
+    it { should validate_presence_of :food_type }
+
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,4 +61,13 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  require 'shoulda/matchers'
+
+  Shoulda::Matchers.configure do |config|
+    config.integrate do |with|
+      with.test_framework :rspec
+      with.library :rails
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,15 @@
 require 'simplecov'
-SimpleCov.start
+
+SimpleCov.start 'rails' do
+  add_filter '/bin/'
+  add_filter '/app/controllers/application_controller.rb'
+  add_filter '/app/channels/'
+  add_filter '/app/jobs/'
+  add_filter '/app/mailers/'
+  add_filter '/db/'
+  add_filter '/spec/' # for rspec
+  add_filter 'app/models/application_record.rb'
+end
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
Created Dinosaur and Cage models with associations.
(Cages have many Dinosaurs)
Cages will default to enum 1 which equals ACTIVE upon creation.


Switched incorrect initial database setup from SQLit3 to PostgreSQL.
Updated SimpleCov ignore files give true representation of test coverage.

Future iterations:
Cages may need a "Name" even though they can be references by Database ID