### PR TITLE
Cage queries

### DIFF
--- a/app/controllers/api/v1/cages_controller.rb
+++ b/app/controllers/api/v1/cages_controller.rb
@@ -1,7 +1,6 @@
 class Api::V1::CagesController < ApplicationController
   def create
     cage = Cage.new(cage_params)
-    
     if cage.save
       render json: CageSerializer.new(cage), status: 201
     else
@@ -9,9 +8,29 @@ class Api::V1::CagesController < ApplicationController
     end
   end
 
+  def index
+    cages = Cage.where(power_status: params[:power_status])
+    if params[:power_status] == "ACTIVE"
+      render json: CageSerializer.new(cages)
+    elsif params[:power_status] == "DOWN"
+      render json: CageSerializer.(cages)
+    else
+      render json: {"data":{"errors": "No cages in system"}}, status: 400
+    end
+  end
+
+  def show
+    cage = Cage.find(params[:id])
+    if cage.nil?
+      render json: {"data":{"errors": "Can not find cage with id #{params[:id]}"}}, status: 400
+    else
+      render json: CageSerializer.new(cage)
+    end
+  end
+
   private
 
   def cage_params
-    params.permit(:capacity)
+    params.permit(:capacity, :power_status)
   end
 end

--- a/app/serializers/cage_serializer.rb
+++ b/app/serializers/cage_serializer.rb
@@ -2,4 +2,8 @@ class CageSerializer
   include FastJsonapi::ObjectSerializer
 
   attributes :capacity, :power_status
+
+  attribute :dinosaurs do |cage|
+    cage.dinosaurs
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       post '/cages', to: 'cages#create'
+      get '/cages', to: 'cages#index'
+      get '/cages/:id', to: 'cages#show'
       post '/dinosaurs', to: 'dinosaurs#create'
     end
   end

--- a/spec/requests/api/v1/cages/cage_queries_spec.rb
+++ b/spec/requests/api/v1/cages/cage_queries_spec.rb
@@ -38,9 +38,11 @@ describe "API V1 Cages", type: 'request' do
         second_cage = Cage.last
 
         json = JSON.parse(response.body, symbolize_names: true)
-        require"pry"; binding.pry
+
         expect(json[:data].length).to eq(2)
         expect(json[:data][0][:id]).to eq(first_cage.id.to_s)
+        expect(json[:data][0][:attributes][:dinosaurs][0][:id]).to eq(@dino1.id)
+        expect(json[:data][0][:attributes][:dinosaurs][0][:name]).to eq(@dino1.name)
         expect(json[:data][1][:id]).to eq(second_cage.id.to_s)
       end
     end

--- a/spec/requests/api/v1/cages/cage_queries_spec.rb
+++ b/spec/requests/api/v1/cages/cage_queries_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+describe "API V1 Cages", type: 'request' do
+  before(:each) do
+    @cage1 = Cage.create(
+      capacity: 1
+    )
+    @cage2 = Cage.create(
+      capacity: 2
+    )
+    @dino1 = Dinosaur.create(
+      name: "Leafy Boy",
+      species: "Stegosaurus",
+      food_type: "Herbivore",
+      cage_id: @cage1.id
+    )
+    @dino2 = Dinosaur.create(
+      name: "Big Claw",
+      species: "Velociraptor",
+      food_type: "Carnivore",
+      cage_id: @cage2.id
+    )
+  end
+
+  describe "GET /api/v1/cages" do
+    context "with valid parameters" do
+      let(:valid_params) do
+        { power_status: "ACTIVE"
+        }
+      end
+
+      it "can get a list of all cages" do
+        get "/api/v1/cages", params: valid_params
+        expect(response).to be_successful
+        expect(response.status).to eq(200)
+
+        first_cage = Cage.first
+        second_cage = Cage.last
+
+        json = JSON.parse(response.body, symbolize_names: true)
+        require"pry"; binding.pry
+        expect(json[:data].length).to eq(2)
+        expect(json[:data][0][:id]).to eq(first_cage.id.to_s)
+        expect(json[:data][1][:id]).to eq(second_cage.id.to_s)
+      end
+    end
+  end
+
+  describe "GET /api/v1/cage/:id" do
+    it "can get a specific cage by its id" do
+      get "/api/v1/cages/#{@cage1.id}"
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      first_cage = Cage.first
+
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      expect(json[:data][:id]).to eq(first_cage.id.to_s)
+    end
+  end
+end


### PR DESCRIPTION
Cages can now be queried

Cage has an individual show page

Cages can be index based on query params of their power status

Cage objects return serialized response of dinos contained within them 


Next iterations: 
Update a cages power status
* note logic already contained that dinos cant be added is power is set to "DOWN"

Dinosaur index by species

README 