### PR TITLE
Cage power update

### DIFF
--- a/app/controllers/api/v1/cages_controller.rb
+++ b/app/controllers/api/v1/cages_controller.rb
@@ -28,6 +28,16 @@ class Api::V1::CagesController < ApplicationController
     end
   end
 
+  def update
+    cage = Cage.find(params[:id])
+    if cage.dinosaurs.any?
+      render json: {"data":{"errors": "Can not power down a cage with dinosaurs in it!"}}, status: 400
+    else
+      cage.update(cage_params)
+      render json: CageSerializer.new(cage)
+    end
+  end
+
   private
 
   def cage_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
       post '/cages', to: 'cages#create'
       get '/cages', to: 'cages#index'
       get '/cages/:id', to: 'cages#show'
+      patch '/cages/:id', to: 'cages#update'
+
       post '/dinosaurs', to: 'dinosaurs#create'
     end
   end

--- a/spec/requests/api/v1/cages/cage_update_spec.rb
+++ b/spec/requests/api/v1/cages/cage_update_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+describe "API V1 Cages", type: 'request' do
+  before(:each) do
+    @cage1 = Cage.create(
+      capacity: 1
+    )
+    @cage2 = Cage.create(
+      capacity: 1
+    )
+    @dino1 = Dinosaur.create(
+      name: "Leafy Boy",
+      species: "Stegosaurus",
+      food_type: "Herbivore",
+      cage_id: @cage2.id
+    )
+  end
+
+  describe "PATCH /api/v1/cages" do
+    context "with valid parameters" do
+      let(:valid_params) do
+        { power_status: "DOWN"
+        }
+      end
+
+      it "can power a cage down if empty" do
+        patch "/api/v1/cages/#{@cage1.id}", params: valid_params
+
+        expect(response).to be_successful
+        expect(response.status).to eq(200)
+
+        cage = Cage.first
+
+        expect(cage.power_status).to eq("DOWN")
+      end
+
+      it "can NOT power a cage down if it has dinos in it" do
+        patch "/api/v1/cages/#{@cage2.id}", params: valid_params
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(400)
+
+        cage = Cage.first
+        json = JSON.parse(response.body, symbolize_names: true)
+
+        expect(cage.power_status).to eq("ACTIVE")
+        expect(json[:data][:errors]).to eq("Can not power down a cage with dinosaurs in it!")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Tests and logic for cage update

Cages can not be powered down if they contain dinosaurs

Next iteration:
Dino queries 
README